### PR TITLE
Add artwork content type and update novel schema

### DIFF
--- a/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
+++ b/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "artworks",
+  "info": {
+    "singularName": "artwork",
+    "pluralName": "artworks",
+    "displayName": "Artwork"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Date": {
+      "type": "date",
+      "required": true
+    },
+    "Title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "required": true
+    },
+    "Body": {
+      "type": "richtext",
+      "required": true
+    },
+    "Note": {
+      "type": "text"
+    }
+  }
+}

--- a/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
+++ b/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
@@ -21,8 +21,7 @@
     },
     "slug": {
       "type": "uid",
-      "required": true,
-      "targetField": "Title"
+      "required": true
     },
     "Body": {
       "type": "richtext",

--- a/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
+++ b/packages/strapi/image/src/api/artwork/content-types/artwork/schema.json
@@ -21,7 +21,8 @@
     },
     "slug": {
       "type": "uid",
-      "required": true
+      "required": true,
+      "targetField": "Title"
     },
     "Body": {
       "type": "richtext",

--- a/packages/strapi/image/src/api/artwork/controllers/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/controllers/artwork.ts
@@ -1,0 +1,7 @@
+/**
+ * artwork controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::artwork.artwork');

--- a/packages/strapi/image/src/api/artwork/controllers/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/controllers/artwork.ts
@@ -2,6 +2,6 @@
  * artwork controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreController('api::artwork.artwork');
+export default factories.createCoreController("api::artwork.artwork");

--- a/packages/strapi/image/src/api/artwork/routes/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/routes/artwork.ts
@@ -1,0 +1,7 @@
+/**
+ * artwork router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::artwork.artwork');

--- a/packages/strapi/image/src/api/artwork/routes/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/routes/artwork.ts
@@ -2,6 +2,6 @@
  * artwork router
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreRouter('api::artwork.artwork');
+export default factories.createCoreRouter("api::artwork.artwork");

--- a/packages/strapi/image/src/api/artwork/services/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/services/artwork.ts
@@ -1,0 +1,7 @@
+/**
+ * artwork service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::artwork.artwork');

--- a/packages/strapi/image/src/api/artwork/services/artwork.ts
+++ b/packages/strapi/image/src/api/artwork/services/artwork.ts
@@ -2,6 +2,6 @@
  * artwork service
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreService('api::artwork.artwork');
+export default factories.createCoreService("api::artwork.artwork");

--- a/packages/strapi/image/src/api/novel/content-types/novel/schema.json
+++ b/packages/strapi/image/src/api/novel/content-types/novel/schema.json
@@ -42,15 +42,6 @@
       },
       "required": true
     },
-    "Description": {
-      "type": "text",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "required": true
-    },
     "Body": {
       "type": "richtext",
       "pluginOptions": {
@@ -59,6 +50,15 @@
         }
       },
       "required": true
+    },
+    "Note": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "required": false
     }
   }
 }

--- a/packages/strapi/image/types/generated/contentTypes.d.ts
+++ b/packages/strapi/image/types/generated/contentTypes.d.ts
@@ -373,6 +373,38 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiArtworkArtwork extends Struct.CollectionTypeSchema {
+  collectionName: "artworks";
+  info: {
+    displayName: "Artwork";
+    pluralName: "artworks";
+    singularName: "artwork";
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    Body: Schema.Attribute.RichText & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+    Date: Schema.Attribute.Date & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::artwork.artwork"
+    > &
+      Schema.Attribute.Private;
+    Note: Schema.Attribute.Text;
+    publishedAt: Schema.Attribute.DateTime;
+    slug: Schema.Attribute.UID & Schema.Attribute.Required;
+    Title: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiNovelNovel extends Struct.CollectionTypeSchema {
   collectionName: "novels";
   info: {
@@ -406,15 +438,14 @@ export interface ApiNovelNovel extends Struct.CollectionTypeSchema {
           localized: false;
         };
       }>;
-    Description: Schema.Attribute.Text &
-      Schema.Attribute.Required &
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::novel.novel">;
+    Note: Schema.Attribute.Text &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
         };
       }>;
-    locale: Schema.Attribute.String;
-    localizations: Schema.Attribute.Relation<"oneToMany", "api::novel.novel">;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID &
       Schema.Attribute.Required &
@@ -945,6 +976,7 @@ declare module "@strapi/strapi" {
       "admin::transfer-token": AdminTransferToken;
       "admin::transfer-token-permission": AdminTransferTokenPermission;
       "admin::user": AdminUser;
+      "api::artwork.artwork": ApiArtworkArtwork;
       "api::novel.novel": ApiNovelNovel;
       "plugin::content-releases.release": PluginContentReleasesRelease;
       "plugin::content-releases.release-action": PluginContentReleasesReleaseAction;


### PR DESCRIPTION
Introduces a new 'artwork' collection type with schema, controller, service, and router in Strapi. Updates the 'novel' content type by replacing 'Description' with 'Body' (richtext) and making 'Note' optional. Updates TypeScript definitions to reflect these schema changes.