### PR TITLE
Fix image height on artwork list page

### DIFF
--- a/packages/web/src/pages/artwork/index.astro
+++ b/packages/web/src/pages/artwork/index.astro
@@ -31,7 +31,7 @@ const artworks = await fetchApi<Artwork[]>({
                   decoding="sync"
                   width="200"
                   height={
-                    artwork.SdrImage.width && artwork.SdrImage.height
+                    artwork.SdrImage.width > 0 && artwork.SdrImage.height > 0
                       ? (200 / artwork.SdrImage.width) * artwork.SdrImage.height
                       : undefined
                   }

--- a/packages/web/src/pages/artwork/index.astro
+++ b/packages/web/src/pages/artwork/index.astro
@@ -30,6 +30,11 @@ const artworks = await fetchApi<Artwork[]>({
                   loading="eager"
                   decoding="sync"
                   width="200"
+                  height={
+                    artwork.SdrImage.width && artwork.SdrImage.height
+                      ? (200 / artwork.SdrImage.width) * artwork.SdrImage.height
+                      : undefined
+                  }
                 />
                 <p>{artwork.Date}</p>
                 <p>{artwork.Title}</p>


### PR DESCRIPTION
This pull request fixes an issue where the image height was not being set correctly on the artwork list page. The height is now calculated dynamically based on the image's aspect ratio, ensuring that the images are displayed correctly. A null check has also been added to prevent errors when the image dimensions are not available.