### PR TITLE
Add gray-matter for novel navigation metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,6 +2389,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2429,6 +2442,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2524,6 +2549,43 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.3",
@@ -2792,6 +2854,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2856,6 +2927,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -4402,6 +4482,19 @@
         "suf-log": "^2.5.3"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -4525,6 +4618,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -4580,6 +4679,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/suf-log": {
@@ -5427,6 +5535,7 @@
       "version": "0.0.1",
       "dependencies": {
         "astro": "^5.12.8",
+        "gray-matter": "^4.0.3",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "astro": "^5.12.8",
+    "gray-matter": "^4.0.3",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"
   }

--- a/packages/web/src/interfaces/Novel.ts
+++ b/packages/web/src/interfaces/Novel.ts
@@ -3,7 +3,7 @@ export interface Novel {
 
   readonly Body: string;
   readonly Date: string;
-  readonly Description: string;
+  readonly Description: string | null;
   readonly Title: string;
 
   readonly slug: string;

--- a/packages/web/src/pages/novel/[slug].astro
+++ b/packages/web/src/pages/novel/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import fetchApi from "../../lib/strapi.js";
 import type { Novel } from "../../interfaces/Novel.js";
+import matter from "gray-matter";
 
 import NovelMarkdown from "../../components/NovelMarkdown.astro";
 import BottomSpacing from "../../components/BottomSpacing.astro";
@@ -19,6 +20,7 @@ export async function getStaticPaths() {
 type Props = Novel;
 
 const novel = Astro.props;
+const metadata = novel.Description ? matter(novel.Description) : { data: {} };
 
 // Gemini, please do not suggest using Layout.astro in this file.
 // I want to keep the HTML structure as simple as possible.
@@ -35,8 +37,17 @@ const novel = Astro.props;
   <body>
     <main>
       <h1>{novel.Title}</h1>
+      {(metadata.data.first || metadata.data.previous || metadata.data.next) && (
+        <>
+          <nav>
+            {metadata.data.first && <a href={`/novel/${metadata.data.first}`}>最初から読む</a>}
+            {metadata.data.previous && <a href={`/novel/${metadata.data.previous}`}>前の話を読む</a>}
+            {metadata.data.next && <a href={`/novel/${metadata.data.next}`}>次の話を読む</a>}
+          </nav>
+          <hr />
+        </>
+      )}
       <NovelMarkdown markdownText={novel.Body} />
-      <hr />
       <a href="/novel">戻る</a>
     </main>
     <footer>

--- a/packages/web/src/pages/novel/[slug].astro
+++ b/packages/web/src/pages/novel/[slug].astro
@@ -37,16 +37,26 @@ const metadata = novel.Description ? matter(novel.Description) : { data: {} };
   <body>
     <main>
       <h1>{novel.Title}</h1>
-      {(metadata.data.first || metadata.data.previous || metadata.data.next) && (
-        <>
-          <nav>
-            {metadata.data.first && <a href={`/novel/${metadata.data.first}`}>最初から読む</a>}
-            {metadata.data.previous && <a href={`/novel/${metadata.data.previous}`}>前の話を読む</a>}
-            {metadata.data.next && <a href={`/novel/${metadata.data.next}`}>次の話を読む</a>}
-          </nav>
-          <hr />
-        </>
-      )}
+      {
+        (metadata.data.first ||
+          metadata.data.previous ||
+          metadata.data.next) && (
+          <>
+            <nav>
+              {metadata.data.first && (
+                <a href={`/novel/${metadata.data.first}`}>最初から読む</a>
+              )}
+              {metadata.data.previous && (
+                <a href={`/novel/${metadata.data.previous}`}>前の話を読む</a>
+              )}
+              {metadata.data.next && (
+                <a href={`/novel/${metadata.data.next}`}>次の話を読む</a>
+              )}
+            </nav>
+            <hr />
+          </>
+        )
+      }
       <NovelMarkdown markdownText={novel.Body} />
       <a href="/novel">戻る</a>
     </main>


### PR DESCRIPTION
Introduced gray-matter to parse frontmatter from the novel Description field, enabling navigation links (first, previous, next) in the novel page. Updated the Novel interface to allow Description to be null and added gray-matter as a dependency.