### PR TITLE
Strapi/update only on publish

### DIFF
--- a/packages/strapi/image/config/plugins.ts
+++ b/packages/strapi/image/config/plugins.ts
@@ -35,12 +35,12 @@ export default ({ env }) => ({
         {
           uid: "api::artwork.artwork",
           eventType: "strapi-artwork-update",
-          actions: ["create", "update", "delete", "publish", "unpublish"],
+          actions: ["publish", "unpublish"],
         },
         {
           uid: "api::novel.novel",
           eventType: "strapi-novel-update",
-          actions: ["create", "update", "delete", "publish", "unpublish"],
+          actions: ["publish", "unpublish"],
         },
       ],
     },

--- a/packages/strapi/src/index.ts
+++ b/packages/strapi/src/index.ts
@@ -17,6 +17,11 @@ export interface Env {
   TRANSFER_TOKEN_SALT: string;
   CF_ACCESS_KEY_ID: string;
   CF_SECRET_ACCESS_KEY: string;
+  GITHUB_APP_ID: string;
+  GITHUB_INSTALLATION_ID: string;
+  GITHUB_PRIVATE_KEY: string;
+  GITHUB_OWNER: string;
+  GITHUB_REPO: string;
 
   // Variables from the [vars] section in wrangler.toml
   CF_ENDPOINT: string;

--- a/packages/strapi/tsconfig.json
+++ b/packages/strapi/tsconfig.json
@@ -12,7 +12,7 @@
     /* Specify what module code is generated. */
     "module": "es2022",
     /* Specify how TypeScript looks up a file from a given module specifier. */
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     /* Enable importing .json files */
     "resolveJsonModule": true,
 


### PR DESCRIPTION
This pull request introduces several configuration updates to the Strapi package, primarily focusing on environment variable support for GitHub integration and refining plugin event triggers. The most significant changes include adding new GitHub-related environment variables, limiting plugin event actions to only publishing-related events, and updating TypeScript module resolution for improved compatibility.

**Environment variable additions:**

* Added new GitHub integration environment variables (`GITHUB_APP_ID`, `GITHUB_INSTALLATION_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_OWNER`, `GITHUB_REPO`) to the `Env` interface in `src/index.ts`, enabling future GitHub API interactions.

**Plugin configuration updates:**

* Restricted the `actions` array for `strapi-artwork-update` and `strapi-novel-update` events in `config/plugins.ts` to only include `publish` and `unpublish`, removing `create`, `update`, and `delete` triggers for these event types.

**TypeScript configuration change:**

* Changed the `moduleResolution` setting in `tsconfig.json` from `node` to `bundler`, improving compatibility with modern bundler tools.