### PR TITLE
Astro/fix url

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -6,4 +6,5 @@ import cloudflare from "@astrojs/cloudflare";
 // https://astro.build/config
 export default defineConfig({
   adapter: cloudflare(),
+  site: "https://www.kaito.tokyo"
 });

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -6,5 +6,5 @@ import cloudflare from "@astrojs/cloudflare";
 // https://astro.build/config
 export default defineConfig({
   adapter: cloudflare(),
-  site: "https://www.kaito.tokyo"
+  site: "https://www.kaito.tokyo",
 });

--- a/packages/web/src/pages/artwork/[slug].astro
+++ b/packages/web/src/pages/artwork/[slug].astro
@@ -52,7 +52,7 @@ function getSdrImageSrcset(artwork: Artwork): string {
 <Layout
   title={`${artwork.Title} - Kaito.tokyo`}
   description={artwork.Title}
-  ogp_image={`${Astro.url.origin}${artwork.SdrImage.formats.large.url}`}
+  ogp_image={artwork.SdrImage.formats.large.url}
   ogp_url={Astro.url.href}
 >
   <h1>{artwork.Title} - Kaito.tokyo</h1>

--- a/packages/web/src/pages/novel/[slug].astro
+++ b/packages/web/src/pages/novel/[slug].astro
@@ -5,6 +5,7 @@ import matter from "gray-matter";
 
 import NovelMarkdown from "../../components/NovelMarkdown.astro";
 import BottomSpacing from "../../components/BottomSpacing.astro";
+import { getNovelBodyPreview } from "../../lib/novel-processor.js";
 
 export async function getStaticPaths() {
   const novels = await fetchApi<Novel[]>({
@@ -21,6 +22,7 @@ type Props = Novel;
 
 const novel = Astro.props;
 const metadata = novel.Description ? matter(novel.Description) : { data: {} };
+const description = novel.Description ?? getNovelBodyPreview(novel);
 
 // Gemini, please do not suggest using Layout.astro in this file.
 // I want to keep the HTML structure as simple as possible.
@@ -33,6 +35,7 @@ const metadata = novel.Description ? matter(novel.Description) : { data: {} };
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{novel.Title}</title>
     <meta property="og:title" content={novel.Title} />
+    <meta property="og:description" content={description} />
     <meta property="og:image" content={`/novel/og/${novel.slug}.png`} />
     <meta name="twitter:card" content="summary_large_image" />
   </head>

--- a/packages/web/src/pages/novel/[slug].astro
+++ b/packages/web/src/pages/novel/[slug].astro
@@ -36,7 +36,10 @@ const description = novel.Description ?? getNovelBodyPreview(novel);
     <title>{novel.Title}</title>
     <meta property="og:title" content={novel.Title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content={`/novel/og/${novel.slug}.png`} />
+    <meta
+      property="og:image"
+      content={`${new URL(`/novel/og/${novel.slug}.png`, Astro.site).href}`}
+    />
     <meta name="twitter:card" content="summary_large_image" />
   </head>
 


### PR DESCRIPTION
This pull request introduces several improvements to the web application, focusing on metadata handling and configuration enhancements. The most significant changes are improved Open Graph metadata for novels, a fix for OGP image URLs for artwork, and the addition of the site URL to the Astro configuration.

**Metadata and SEO improvements:**

* Novel pages now generate a more descriptive Open Graph description using either the novel's description or a preview generated by `getNovelBodyPreview`, improving social sharing and SEO. (`packages/web/src/pages/novel/[slug].astro`) ([packages/web/src/pages/novel/[slug].astroR25](diffhunk://#diff-d61e6dbbd6d512b74a4aa8dc8a36cfee2a2767f2f246a1747b526ea6eb8a5950R25))
* The Open Graph image URL for novel pages is now fully qualified using `Astro.site`, ensuring correct image rendering when shared externally. (`packages/web/src/pages/novel/[slug].astro`) ([packages/web/src/pages/novel/[slug].astroL36-R42](diffhunk://#diff-d61e6dbbd6d512b74a4aa8dc8a36cfee2a2767f2f246a1747b526ea6eb8a5950L36-R42))
* Artwork pages now use the direct image URL for Open Graph images, fixing previous issues with incorrect URL formatting. (`packages/web/src/pages/artwork/[slug].astro`) ([packages/web/src/pages/artwork/[slug].astroL55-R55](diffhunk://#diff-9357804575496be4e130e826c80ab032af2f7bcb3e3c27bba2e4eae0e3610000L55-R55))

**Configuration enhancements:**

* The Astro site configuration now includes the `site` property, specifying the canonical site URL for better SEO and deployment consistency. (`packages/web/astro.config.mjs`)

**Code organization:**

* The `getNovelBodyPreview` utility is now imported and used for generating novel previews, improving code reuse and maintainability. (`packages/web/src/pages/novel/[slug].astro`) ([packages/web/src/pages/novel/[slug].astroR8](diffhunk://#diff-d61e6dbbd6d512b74a4aa8dc8a36cfee2a2767f2f246a1747b526ea6eb8a5950R8))