### PR TITLE
Add NovelApp interface and novel-app pages

### DIFF
--- a/packages/web/src/interfaces/NovelApp.ts
+++ b/packages/web/src/interfaces/NovelApp.ts
@@ -1,0 +1,10 @@
+export interface NovelApp {
+  readonly id: number;
+
+  readonly Html: string;
+  readonly slug: string;
+
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly publishedAt: string;
+}

--- a/packages/web/src/pages/novel-app/[slug].astro
+++ b/packages/web/src/pages/novel-app/[slug].astro
@@ -1,0 +1,22 @@
+---
+import fetchApi from "../../lib/strapi.js";
+import type { NovelApp } from "../../interfaces/NovelApp.js";
+import Layout from "../../layouts/Layout.astro";
+
+export async function getStaticPaths() {
+  const novelApps = await fetchApi<NovelApp[]>({
+    endpoint: "novel-apps",
+    wrappedByKey: "data",
+  });
+
+  return novelApps.map((app) => ({
+    params: { slug: app.slug },
+    props: app,
+  }));
+}
+type Props = NovelApp;
+
+const app = Astro.props;
+---
+
+<html set:html={app.Html} />

--- a/packages/web/src/pages/novel-app/index.astro
+++ b/packages/web/src/pages/novel-app/index.astro
@@ -1,0 +1,30 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import fetchApi from "../../lib/strapi.js";
+import type { NovelApp } from "../../interfaces/NovelApp.js";
+
+const novelApps = await fetchApi<NovelApp[]>({
+  endpoint: "novel-apps?sort=publishedAt:desc",
+  wrappedByKey: "data",
+});
+---
+
+<Layout title="アプリ - kaito.tokyo">
+  <h1>アプリ</h1>
+  <ul>
+    {
+      novelApps.map((app) => (
+        <li>
+          <a href={`/novel-app/${app.slug}`}>{app.slug}</a>
+        </li>
+      ))
+    }
+  </ul>
+</Layout>
+
+<style>
+  ul {
+    padding: 0;
+    list-style: none;
+  }
+</style>


### PR DESCRIPTION
This pull request introduces a new `NovelApp` feature to the web package, enabling listing and viewing of individual novel apps. The main changes include defining the `NovelApp` interface, creating a page to list all novel apps, and implementing dynamic routing for individual app pages.

**NovelApp feature implementation:**

* Added a new `NovelApp` interface in `packages/web/src/interfaces/NovelApp.ts` to define the shape of novel app data.

**NovelApp listing and routing:**

* Created `packages/web/src/pages/novel-app/index.astro` to fetch and display a list of novel apps, sorted by publish date, with links to each app's detail page.
* Added dynamic routing in `packages/web/src/pages/novel-app/[slug].astro` to render individual novel app pages using the `Html` property from the API response. ([packages/web/src/pages/novel-app/[slug].astroR1-R22](diffhunk://#diff-0f1024ce72e0683b004dfb378c609f11385c5262517bc02e26ff95a4492570f3R1-R22))Introduces the NovelApp TypeScript interface and two Astro pages: one for listing all novel apps and one for displaying individual novel app details by slug. Fetches data from the API and renders HTML content dynamically.