### PR TITLE
Update novel-app schema with new attributes

### DIFF
--- a/packages/strapi/image/src/api/novel-app/content-types/novel-app/schema.json
+++ b/packages/strapi/image/src/api/novel-app/content-types/novel-app/schema.json
@@ -15,7 +15,23 @@
       "type": "uid",
       "required": true
     },
-    "Html": {
+    "Title": {
+      "type": "string",
+      "required": true
+    },
+    "Description": {
+      "type": "text",
+      "required": true
+    },
+    "Lang": {
+      "type": "string",
+      "required": true
+    },
+    "Head": {
+      "type": "text",
+      "required": true
+    },
+    "Body": {
       "type": "text",
       "required": true
     }

--- a/packages/strapi/image/types/generated/contentTypes.d.ts
+++ b/packages/strapi/image/types/generated/contentTypes.d.ts
@@ -417,10 +417,13 @@ export interface ApiNovelAppNovelApp extends Struct.CollectionTypeSchema {
     draftAndPublish: true;
   };
   attributes: {
+    Body: Schema.Attribute.Text & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
-    Html: Schema.Attribute.Text & Schema.Attribute.Required;
+    Description: Schema.Attribute.Text & Schema.Attribute.Required;
+    Head: Schema.Attribute.Text & Schema.Attribute.Required;
+    Lang: Schema.Attribute.String & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       "oneToMany",
@@ -429,6 +432,7 @@ export interface ApiNovelAppNovelApp extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID & Schema.Attribute.Required;
+    Title: Schema.Attribute.String & Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;


### PR DESCRIPTION
This pull request updates the schema for the `novel-app` content type to improve its structure and clarity. The main change is the replacement of the single `Html` field with several more descriptive fields that better represent the components of a novel app entry.

Schema improvements:

* Replaced the `Html` field with five new fields: `Title` (string), `Description` (text), `Lang` (string), `Head` (text), and `Body` (text), all of which are required. This change makes the schema more explicit and easier to work with.Replaced 'Html' with 'Title', 'Description', 'Lang', 'Head', and 'Body' fields in the novel-app content type schema and updated the corresponding TypeScript definitions. This change provides a more structured representation of novel-app content.