### PR TITLE
Astro/novel app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
+.astro
 .wrangler/
+dist/
 node_modules/

--- a/packages/web/src/interfaces/NovelApp.ts
+++ b/packages/web/src/interfaces/NovelApp.ts
@@ -1,8 +1,12 @@
 export interface NovelApp {
   readonly id: number;
 
-  readonly Html: string;
   readonly slug: string;
+  readonly Title: string;
+  readonly Description: string;
+  readonly Lang: string;
+  readonly Head: string;
+  readonly Body: string;
 
   readonly createdAt: string;
   readonly updatedAt: string;

--- a/packages/web/src/interfaces/NovelApp.ts
+++ b/packages/web/src/interfaces/NovelApp.ts
@@ -1,0 +1,10 @@
+export interface NovelApp {
+  readonly id: number;
+
+  readonly Html: string;
+  readonly slug: string;
+
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly publishedAt: string;
+}

--- a/packages/web/src/pages/novel-app/[slug].astro
+++ b/packages/web/src/pages/novel-app/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import fetchApi from "../../lib/strapi.js";
 import type { NovelApp } from "../../interfaces/NovelApp.js";
-import Layout from "../../layouts/Layout.astro";
 
 export async function getStaticPaths() {
   const novelApps = await fetchApi<NovelApp[]>({
@@ -17,6 +16,24 @@ export async function getStaticPaths() {
 type Props = NovelApp;
 
 const app = Astro.props;
+const description = app.Description ?? "";
 ---
 
-<html set:html={app.Html} />
+<!doctype html>
+<html lang={app.Lang}>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{app.Title}</title>
+    <meta property="og:title" content={app.Title} />
+    <meta property="og:description" content={description} />
+    <meta
+      property="og:image"
+      content={`${new URL(`/novel-app/og/${app.slug}.png`, Astro.site).href}`}
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <Fragment set:html={app.Head} />
+  </head>
+
+  <body set:html={app.Body} />
+</html>

--- a/packages/web/src/pages/novel-app/[slug].astro
+++ b/packages/web/src/pages/novel-app/[slug].astro
@@ -1,0 +1,22 @@
+---
+import fetchApi from "../../lib/strapi.js";
+import type { NovelApp } from "../../interfaces/NovelApp.js";
+import Layout from "../../layouts/Layout.astro";
+
+export async function getStaticPaths() {
+  const novelApps = await fetchApi<NovelApp[]>({
+    endpoint: "novel-apps",
+    wrappedByKey: "data",
+  });
+
+  return novelApps.map((app) => ({
+    params: { slug: app.slug },
+    props: app,
+  }));
+}
+type Props = NovelApp;
+
+const app = Astro.props;
+---
+
+<html set:html={app.Html} />

--- a/packages/web/src/pages/novel-app/index.astro
+++ b/packages/web/src/pages/novel-app/index.astro
@@ -1,0 +1,30 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import fetchApi from "../../lib/strapi.js";
+import type { NovelApp } from "../../interfaces/NovelApp.js";
+
+const novelApps = await fetchApi<NovelApp[]>({
+  endpoint: "novel-apps?sort=publishedAt:desc",
+  wrappedByKey: "data",
+});
+---
+
+<Layout title="アプリ - kaito.tokyo">
+  <h1>アプリ</h1>
+  <ul>
+    {
+      novelApps.map((app) => (
+        <li>
+          <a href={`/novel-app/${app.slug}`}>{app.slug}</a>
+        </li>
+      ))
+    }
+  </ul>
+</Layout>
+
+<style>
+  ul {
+    padding: 0;
+    list-style: none;
+  }
+</style>

--- a/packages/web/src/pages/novel-app/og/[slug].png.ts
+++ b/packages/web/src/pages/novel-app/og/[slug].png.ts
@@ -1,0 +1,100 @@
+import satori from "satori";
+import sharp from "sharp";
+import fetchApi from "../../../lib/strapi";
+import type { NovelApp } from "../../../interfaces/NovelApp";
+import fs from "fs";
+import path from "path";
+import type { APIRoute } from "astro";
+
+export async function getStaticPaths() {
+  const novelApps = await fetchApi<NovelApp[]>({
+    endpoint: "novel-apps",
+    wrappedByKey: "data",
+  });
+
+  return novelApps.map((app) => ({
+    params: { slug: app.slug },
+    props: app,
+  }));
+}
+
+export const GET: APIRoute<NovelApp> = async ({ props }) => {
+  const app = props;
+
+  const fontPath = path.resolve(
+    "./src/assets/fonts/NotoSerifJP-ExtraLight.ttf",
+  );
+  const fontData = fs.readFileSync(fontPath);
+  const boldFontPath = path.resolve("./src/assets/fonts/NotoSerifJP-Bold.ttf");
+  const boldFontData = fs.readFileSync(boldFontPath);
+
+  const template = {
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        width: "1200px",
+        height: "630px",
+        padding: "40px",
+        backgroundColor: "#f5f5f5",
+        border: "20px solid #e0e0e0",
+      },
+      children: [
+        {
+          type: "div",
+          props: {
+            style: {
+              fontFamily: "Noto Serif JP Bold",
+              fontSize: "40px",
+              marginBottom: "20px",
+            },
+            children: `『${app.Title}』`,
+          },
+        },
+        {
+          type: "div",
+          props: {
+            style: {
+              fontSize: "40px",
+              textOverflow: "ellipsis",
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitBoxOrient: "vertical",
+              WebkitLineClamp: 7,
+              textIndent: "1em",
+            },
+            children: app.Description,
+          },
+        },
+      ],
+    },
+  };
+
+  const svg = await satori(template, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      {
+        name: "Noto Serif JP",
+        data: fontData,
+        weight: 200,
+        style: "normal",
+      },
+      {
+        name: "Noto Serif JP Bold",
+        data: boldFontData,
+        weight: 700,
+        style: "normal",
+      },
+    ],
+  });
+
+  const png = await sharp(Buffer.from(svg)).png().toBuffer();
+
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+    },
+  });
+};

--- a/packages/web/src/pages/novel-app/og/[slug].png.ts
+++ b/packages/web/src/pages/novel-app/og/[slug].png.ts
@@ -92,7 +92,7 @@ export const GET: APIRoute<NovelApp> = async ({ props }) => {
 
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
-  return new Response(new Uint8Array(png), {
+  return new Response(png, {
     headers: {
       "Content-Type": "image/png",
     },


### PR DESCRIPTION
This pull request refactors the `NovelApp` interface and the `[slug].astro` page to improve semantic HTML, metadata, and support for Open Graph images. It also introduces a new API route for dynamically generating Open Graph PNG images for each novel app using Satori and Sharp.

**Interface and Metadata Improvements:**

* Expanded the `NovelApp` interface to include `Title`, `Description`, `Lang`, `Head`, and `Body` fields, and removed the single `Html` field for more granular content and metadata control.
* Refactored the `[slug].astro` page to use semantic HTML, set language and metadata tags, render Open Graph and Twitter meta tags, and inject custom head/body HTML from the app data. ([packages/web/src/pages/novel-app/[slug].astroR19-R39](diffhunk://#diff-0f1024ce72e0683b004dfb378c609f11385c5262517bc02e26ff95a4492570f3R19-R39))

**Open Graph Image Generation:**

* Added a new API route `og/[slug].png.ts` that generates a PNG Open Graph image for each novel app using Satori for SVG rendering and Sharp for PNG conversion. The image includes the app's title and description styled with custom fonts. ([packages/web/src/pages/novel-app/og/[slug].png.tsR1-R100](diffhunk://#diff-d3263b818bba9b14511ee56a1bc4d678f8efc9bad7cf655252a802a22e498921R1-R100))