### PR TITLE
Add Vip boolean field to novel-app schema

### DIFF
--- a/packages/strapi/image/src/api/novel-app/content-types/novel-app/schema.json
+++ b/packages/strapi/image/src/api/novel-app/content-types/novel-app/schema.json
@@ -27,6 +27,9 @@
       "type": "string",
       "required": true
     },
+    "Vip": {
+      "type": "boolean"
+    },
     "Head": {
       "type": "text",
       "required": true

--- a/packages/strapi/image/types/generated/contentTypes.d.ts
+++ b/packages/strapi/image/types/generated/contentTypes.d.ts
@@ -436,6 +436,7 @@ export interface ApiNovelAppNovelApp extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
+    Vip: Schema.Attribute.Boolean;
   };
 }
 


### PR DESCRIPTION
This pull request introduces a minor update to the `novel-app` content type schema by adding a new field. The change expands the schema to support additional functionality.

* Schema enhancement:
  * Added a new boolean field `Vip` to the `novel-app` content type schema in `packages/strapi/image/src/api/novel-app/content-types/novel-app/schema.json`.Introduces a new 'Vip' boolean attribute to the novel-app content type schema and updates the corresponding TypeScript type definition. This allows novel-app entries to indicate VIP status.