### PR TITLE
Pin wrangler-action to v3.14.1 in workflows

### DIFF
--- a/.github/workflows/deploy-strapi-wrangler.yaml
+++ b/.github/workflows/deploy-strapi-wrangler.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Deploy Wrangler"
-        uses: "cloudflare/wrangler-action@v3"
+        uses: "cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65" # v3.14.1
         with:
           apiToken: "${{ secrets.CLOUDFLARE_API_TOKEN }}"
           accountId: "${{ vars.CLOUDFLARE_ACCOUNT_ID }}"

--- a/.github/workflows/deploy-web-wrangler.yaml
+++ b/.github/workflows/deploy-web-wrangler.yaml
@@ -45,7 +45,7 @@ jobs:
           STRAPI_URL: "https://strapi.kaito.tokyo"
 
       - name: "Deploy Wrangler"
-        uses: "cloudflare/wrangler-action@v3"
+        uses: "cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65" # v3.14.1
         with:
           apiToken: "${{ secrets.CLOUDFLARE_API_TOKEN }}"
           accountId: "${{ vars.CLOUDFLARE_ACCOUNT_ID }}"

--- a/.github/workflows/pr-web-wrangler-versions-upload.yaml
+++ b/.github/workflows/pr-web-wrangler-versions-upload.yaml
@@ -40,7 +40,7 @@ jobs:
           STRAPI_URL: "https://strapi.kaito.tokyo"
 
       - name: "Deploy Wrangler"
-        uses: "cloudflare/wrangler-action@v3"
+        uses: "cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65" # v3.14.1
         with:
           apiToken: "${{ secrets.CLOUDFLARE_API_TOKEN }}"
           accountId: "${{ inputs.CLOUDFLARE_ACCOUNT_ID }}"


### PR DESCRIPTION
Updated the Cloudflare wrangler-action in deployment workflows to use a specific commit hash for v3.14.1 instead of the generic v3 tag. This ensures consistent and reproducible builds by avoiding unexpected updates from the v3 tag.