### PR TITLE
Add VIP support for NovelApp pages

### DIFF
--- a/packages/web/src/interfaces/NovelApp.ts
+++ b/packages/web/src/interfaces/NovelApp.ts
@@ -7,6 +7,7 @@ export interface NovelApp {
   readonly Lang: string;
   readonly Head: string;
   readonly Body: string;
+  readonly Vip: boolean;
 
   readonly createdAt: string;
   readonly updatedAt: string;

--- a/packages/web/src/pages/novel-app/[slug].astro
+++ b/packages/web/src/pages/novel-app/[slug].astro
@@ -37,5 +37,5 @@ const app = Astro.props;
     <Fragment set:html={app.Head} />
   </head>
 
-  <body set:html={app.Body} />
+  <Fragment set:html={app.Body} />
 </html>

--- a/packages/web/src/pages/novel-app/[slug].astro
+++ b/packages/web/src/pages/novel-app/[slug].astro
@@ -3,12 +3,15 @@ import fetchApi from "../../lib/strapi.js";
 import type { NovelApp } from "../../interfaces/NovelApp.js";
 
 export async function getStaticPaths() {
-  const novelApps = await fetchApi<NovelApp[]>({
+  const publicNovelApps = await fetchApi<NovelApp[]>({
     endpoint: "novel-apps",
     wrappedByKey: "data",
+    query: {
+      "filters[Vip][$eq]": "false",
+    },
   });
 
-  return novelApps.map((app) => ({
+  return publicNovelApps.map((app) => ({
     params: { slug: app.slug },
     props: app,
   }));
@@ -16,7 +19,6 @@ export async function getStaticPaths() {
 type Props = NovelApp;
 
 const app = Astro.props;
-const description = app.Description ?? "";
 ---
 
 <!doctype html>
@@ -26,7 +28,7 @@ const description = app.Description ?? "";
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{app.Title}</title>
     <meta property="og:title" content={app.Title} />
-    <meta property="og:description" content={description} />
+    <meta property="og:description" content={app.Description} />
     <meta
       property="og:image"
       content={`${new URL(`/novel-app/og/${app.slug}.png`, Astro.site).href}`}

--- a/packages/web/src/pages/novel-app/index.astro
+++ b/packages/web/src/pages/novel-app/index.astro
@@ -15,7 +15,9 @@ const novelApps = await fetchApi<NovelApp[]>({
     {
       novelApps.map((app) => (
         <li>
-          <a href={`${app.Vip ? "/vip" : ""}/novel-app/${app.slug}`}>{app.Title}</a>
+          <a href={`${app.Vip ? "/vip" : ""}/novel-app/${app.slug}`}>
+            {app.Title}
+          </a>
         </li>
       ))
     }

--- a/packages/web/src/pages/novel-app/index.astro
+++ b/packages/web/src/pages/novel-app/index.astro
@@ -15,7 +15,7 @@ const novelApps = await fetchApi<NovelApp[]>({
     {
       novelApps.map((app) => (
         <li>
-          <a href={`/novel-app/${app.slug}`}>{app.slug}</a>
+          <a href={`${app.Vip ? "/vip" : ""}/novel-app/${app.slug}`}>{app.Title}</a>
         </li>
       ))
     }

--- a/packages/web/src/pages/vip/novel-app/[slug].astro
+++ b/packages/web/src/pages/vip/novel-app/[slug].astro
@@ -1,0 +1,34 @@
+---
+import fetchApi from "../../../lib/strapi.js";
+import type { NovelApp } from "../../../interfaces/NovelApp.js";
+
+export async function getStaticPaths() {
+  const vipNovelApps = await fetchApi<NovelApp[]>({
+    endpoint: "novel-apps",
+    wrappedByKey: "data",
+    query: {
+      "filters[Vip][$eq]": "true",
+    },
+  });
+
+  return vipNovelApps.map((app) => ({
+    params: { slug: app.slug },
+    props: app,
+  }));
+}
+type Props = NovelApp;
+
+const app = Astro.props;
+---
+
+<!doctype html>
+<html lang={app.Lang}>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{app.Title}</title>
+    <Fragment set:html={app.Head} />
+  </head>
+
+  <Fragment set:html={app.Body} />
+</html>


### PR DESCRIPTION
This pull request introduces support for distinguishing between VIP and public novel apps in the web interface. The changes add a `Vip` flag to the `NovelApp` interface, filter novel apps by VIP status when generating static paths, and route VIP apps to a dedicated URL structure. These updates ensure that VIP novel apps are handled and displayed separately from public ones.

**VIP/Public Novel App Separation:**

* Added a `Vip` boolean property to the `NovelApp` interface to identify VIP apps.
* Updated static path generation in `novel-app/[slug].astro` to filter and display only public (non-VIP) novel apps. ([packages/web/src/pages/novel-app/[slug].astroL6-L19](diffhunk://#diff-0f1024ce72e0683b004dfb378c609f11385c5262517bc02e26ff95a4492570f3L6-L19))
* Created a new page at `vip/novel-app/[slug].astro` for VIP novel apps, with static paths filtered to include only VIP entries. ([packages/web/src/pages/vip/novel-app/[slug].astroR1-R34](diffhunk://#diff-32b49042bbda54e2a56a6986522f4b10a1a0d3cd939d8c270e21de89d9a59115R1-R34))

**Routing and Display Adjustments:**

* Changed novel app listing in `novel-app/index.astro` to route VIP apps to `/vip/novel-app/[slug]` and public apps to `/novel-app/[slug]`, and display the app title instead of the slug.

**Meta Tag Consistency:**

* Updated the Open Graph description meta tag to use `app.Description` directly in `novel-app/[slug].astro`. ([packages/web/src/pages/novel-app/[slug].astroL29-R31](diffhunk://#diff-0f1024ce72e0683b004dfb378c609f11385c5262517bc02e26ff95a4492570f3L29-R31))Introduces a 'Vip' boolean to the NovelApp interface and splits novel-app pages into public and VIP versions. Updates routing and filtering logic to display VIP apps under /vip/novel-app and public apps under /novel-app, ensuring correct links and metadata.