### PR TITLE
Update rotate_secrets.sh

### DIFF
--- a/packages/strapi/rotate_secrets.sh
+++ b/packages/strapi/rotate_secrets.sh
@@ -2,13 +2,13 @@
 
 r()
 {
-  openssl rand -base64 64 | tr -d '\n'
+  openssl rand -base64 "$1" | tr -d '\n'
 }
 
-echo "$(r),$(r),$(r),$(r)" | npx wrangler secret put APP_KEYS
+echo "$(r 64),$(r 64),$(r 64),$(r 64)" | npx wrangler secret put APP_KEYS
 
-r | npx wrangler secret put ADMIN_JWT_SECRET
-r | npx wrangler secret put API_TOKEN_SALT
-r | npx wrangler secret put ENCRYPTION_KEY
-r | npx wrangler secret put JWT_SECRET
-r | npx wrangler secret put TRANSFER_TOKEN_SALT
+r 64 | npx wrangler secret put ADMIN_JWT_SECRET
+r 64 | npx wrangler secret put API_TOKEN_SALT
+r 64 | npx wrangler secret put ENCRYPTION_KEY
+r 64 | npx wrangler secret put JWT_SECRET
+r 64 | npx wrangler secret put TRANSFER_TOKEN_SALT


### PR DESCRIPTION
This pull request updates the `rotate_secrets.sh` script to allow specifying the length of generated secrets, improving flexibility and consistency in secret generation.

Improvements to secret generation:

* Modified the `r()` function to accept a length parameter, allowing for variable-length secret generation instead of a fixed length.
* Updated all secret generation calls to explicitly use a length of 64 bytes for each secret, ensuring consistency across all secrets.