### PR TITLE
Add required Date field to roleplay-actor schema

### DIFF
--- a/packages/strapi/image/src/api/roleplay-actor/content-types/roleplay-actor/schema.json
+++ b/packages/strapi/image/src/api/roleplay-actor/content-types/roleplay-actor/schema.json
@@ -15,6 +15,10 @@
       "type": "uid",
       "required": true
     },
+    "Date": {
+      "type": "date",
+      "required": true
+    },
     "Name": {
       "type": "string",
       "required": true

--- a/packages/strapi/image/types/generated/contentTypes.d.ts
+++ b/packages/strapi/image/types/generated/contentTypes.d.ts
@@ -517,6 +517,7 @@ export interface ApiRoleplayActorRoleplayActor
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private;
+    Date: Schema.Attribute.Date & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       "oneToMany",


### PR DESCRIPTION
This pull request adds a new required `Date` field to the `roleplay-actor` content type schema. This change ensures that every `roleplay-actor` entry must now include a date value.

* Schema update:
  * Added a required `Date` field of type `date` to the `roleplay-actor` schema in `packages/strapi/image/src/api/roleplay-actor/content-types/roleplay-actor/schema.json`.Introduces a new required 'Date' field of type 'date' to the roleplay-actor content type schema and updates the corresponding TypeScript definitions to reflect this change.