### PR TITLE
Add OpenID configuration endpoint

### DIFF
--- a/packages/web/api/src/api-internal-token.ts
+++ b/packages/web/api/src/api-internal-token.ts
@@ -102,3 +102,12 @@ export async function generateApiInternalToken<T>(
     ALGORITHM,
   );
 }
+
+export function getOpenIDConfiguration() {
+  return {
+    issuer: ISSUER,
+    response_types_supported: ["token"],
+    subject_types_supported: ["public"],
+    id_token_signing_alg_values_supported: [ALGORITHM],
+  };
+}

--- a/packages/web/api/src/index.ts
+++ b/packages/web/api/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import type { RoleplayActor } from "../../src/interfaces/RoleplayActor";
 import {
   generateApiInternalToken,
+  getOpenIDConfiguration,
   verifyApiInternalToken,
 } from "./api-internal-token";
 
@@ -137,6 +138,10 @@ app.post("/api/vip/roleplay-chat/:slug", async (c) => {
   });
 
   return c.json({ response, previousState });
+});
+
+app.get("/api/internal/.well-known/openid-configuration", (c) => {
+  return c.json(getOpenIDConfiguration());
 });
 
 export default app;


### PR DESCRIPTION
This pull request introduces support for OpenID Connect discovery in the internal API by adding a new endpoint that serves the OpenID configuration. The main changes are the addition of a helper function to generate the OpenID configuration and the registration of a new route to expose this information.

**OpenID Connect support:**

* Added a new function `getOpenIDConfiguration` to `api-internal-token.ts` that returns the issuer, supported response types, subject types, and signing algorithms.
* Registered a new GET endpoint `/api/internal/.well-known/openid-configuration` in `index.ts` to serve the OpenID configuration using the newly added helper.
* Updated imports in `index.ts` to include the new `getOpenIDConfiguration` function.Introduces getOpenIDConfiguration function and registers a new endpoint at /api/internal/.well-known/openid-configuration to serve OpenID provider metadata.