### PR TITLE
Add roleplay actor event to deployment workflow

### DIFF
--- a/.github/workflows/deploy-web-wrangler.yaml
+++ b/.github/workflows/deploy-web-wrangler.yaml
@@ -15,6 +15,7 @@ on:
     types:
       - "strapi-artwork-update"
       - "strapi-novel-update"
+      - "strapi-roleplay-actor-update"
 
 concurrency:
   group: "${{ github.workflow }}"

--- a/packages/strapi/image/config/plugins.ts
+++ b/packages/strapi/image/config/plugins.ts
@@ -43,7 +43,7 @@ export default ({ env }) => ({
           actions: ["create", "update", "delete", "publish", "unpublish"],
         },
         {
-          uid: "api::roleplay-actor.roleplay^actor",
+          uid: "api::roleplay-actor.roleplay-actor",
           eventType: "strapi-roleplay-actor-update",
           actions: ["create", "update", "delete", "publish", "unpublish"],
         },

--- a/packages/strapi/image/config/plugins.ts
+++ b/packages/strapi/image/config/plugins.ts
@@ -42,6 +42,11 @@ export default ({ env }) => ({
           eventType: "strapi-novel-update",
           actions: ["create", "update", "delete", "publish", "unpublish"],
         },
+        {
+          uid: "api::roleplay-actor.roleplay^actor",
+          eventType: "strapi-roleplay-actor-update",
+          actions: ["create", "update", "delete", "publish", "unpublish"],
+        },
       ],
     },
   },


### PR DESCRIPTION
This pull request adds support for handling events related to the `roleplay-actor` content type in the deployment workflow and Strapi plugin configuration. This ensures that updates to `roleplay-actor` entries will trigger the appropriate automation and event handling processes.

Event handling improvements:

* [`.github/workflows/deploy-web-wrangler.yaml`](diffhunk://#diff-7244537df872d893716d4a0c0813f4a0e2b2ca396b1b07589dbc09f2d5eee9deR18): Added `"strapi-roleplay-actor-update"` to the list of event types that trigger the deployment workflow, enabling automation for changes to `roleplay-actor` entries.

Strapi plugin configuration:

* [`packages/strapi/image/config/plugins.ts`](diffhunk://#diff-6975007c1c614c5bab3f027f43a75e2cdd5ab950caa5b147a8f1d70ac57d153fR45-R49): Registered a new event handler for the `roleplay-actor` content type, allowing actions such as create, update, delete, publish, and unpublish to be tracked and processed.Included 'strapi-roleplay-actor-update' in the GitHub Actions workflow trigger and updated Strapi image plugin config to handle roleplay actor events. This enables automated deployment and event handling for roleplay actor updates.